### PR TITLE
Add new component tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
     // Handle module aliases (this will be automatically configured for you soon)
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  transformIgnorePatterns: [],
   // Automatically clear mock calls, instances, contexts and results before every test
   clearMocks: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5"
+        "typescript": "^5",
+        "whatwg-fetch": "^3.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12788,6 +12789,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test": "jest --watch"
   },
   "dependencies": {
-    "@google-cloud/text-to-speech": "^5.3.0",
     "@genkit-ai/googleai": "^1.8.0",
     "@genkit-ai/next": "^1.8.0",
+    "@google-cloud/text-to-speech": "^5.3.0",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -57,6 +57,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "whatwg-fetch": "^3.6.2"
   }
 }

--- a/src/components/__tests__/AppContent.test.tsx
+++ b/src/components/__tests__/AppContent.test.tsx
@@ -3,6 +3,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AppContent from '../page/AppContent';
 import { ChatProvider } from '../ChatProvider';
+import { generateChatTitle } from '@/ai/flows/generate-chat-title';
+import { getPollinationsChatCompletion } from '@/ai/flows/pollinations-chat-flow';
+import { textToSpeech } from '@/ai/flows/tts-flow';
+
+jest.mock('@/ai/flows/generate-chat-title', () => ({ generateChatTitle: jest.fn() }));
+jest.mock('@/ai/flows/pollinations-chat-flow', () => ({ getPollinationsChatCompletion: jest.fn() }));
+jest.mock('@/ai/flows/tts-flow', () => ({ textToSpeech: jest.fn() }));
+jest.mock('@/ai/flows/stt-flow', () => ({ speechToText: jest.fn() }));
+jest.mock('lucide-react', () => ({ RefreshCw: () => <svg /> }));
+jest.mock('../dialogs/EditTitleDialog', () => () => <div>EditTitleDialog</div>);
+jest.mock('../page/AppHeader', () => () => <div>AppHeader</div>);
 
 // Mock child components to isolate AppContent
 jest.mock('../page/HomePage', () => ({ onSelectTile }: { onSelectTile: (id: string) => void }) => (

--- a/src/components/__tests__/ChatInput.test.tsx
+++ b/src/components/__tests__/ChatInput.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ChatInput from '../chat/ChatInput';
+import { AVAILABLE_POLLINATIONS_MODELS, AVAILABLE_RESPONSE_STYLES, AVAILABLE_TTS_VOICES } from '@/config/chat-options';
+jest.mock('lucide-react', () => ({
+  Mic: () => <svg />,
+  MicOff: () => <svg />,
+  ImageIcon: () => <svg />,
+  X: () => <svg />,
+  Paperclip: () => <svg />,
+  Send: () => <svg />,
+  Brain: () => <svg />,
+  Fingerprint: () => <svg />,
+  Speech: () => <svg />,
+}));
+
+const baseProps = {
+  onSendMessage: jest.fn(),
+  isLoading: false,
+  isImageModeActive: false,
+  onToggleImageMode: jest.fn(),
+  uploadedFilePreviewUrl: null as string | null,
+  onFileSelect: jest.fn(),
+  isLongLanguageLoopActive: false,
+  selectedModelId: AVAILABLE_POLLINATIONS_MODELS[0].id,
+  selectedResponseStyleName: AVAILABLE_RESPONSE_STYLES[0].name,
+  onModelChange: jest.fn(),
+  onStyleChange: jest.fn(),
+  isRecording: false,
+  onToggleRecording: jest.fn(),
+  inputValue: '',
+  onInputChange: jest.fn(),
+  selectedVoice: AVAILABLE_TTS_VOICES[0].id,
+  onVoiceChange: jest.fn(),
+};
+
+describe('ChatInput Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends a message when Enter is pressed', () => {
+    render(<ChatInput {...baseProps} inputValue="Hello" />);
+    const textarea = screen.getByLabelText('Chat message input');
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(baseProps.onSendMessage).toHaveBeenCalledWith('Hello', { isImageModeIntent: undefined });
+  });
+
+  it('calls onFileSelect when a file is uploaded', () => {
+    const { container } = render(<ChatInput {...baseProps} />);
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(baseProps.onFileSelect).toHaveBeenCalledWith(file);
+    expect(fileInput.value).toBe('');
+  });
+});

--- a/src/components/__tests__/ChatProvider.test.tsx
+++ b/src/components/__tests__/ChatProvider.test.tsx
@@ -1,14 +1,16 @@
 import { renderHook, act } from '@testing-library/react';
-import { useChatLogic } from '../ChatProvider';
 import { generateChatTitle } from '@/ai/flows/generate-chat-title';
 import { getPollinationsChatCompletion } from '@/ai/flows/pollinations-chat-flow';
 import { textToSpeech } from '@/ai/flows/tts-flow';
 
 // Mock AI flows to prevent actual API calls during tests
-jest.mock('@/ai/flows/generate-chat-title');
-jest.mock('@/ai/flows/pollinations-chat-flow');
-jest.mock('@/ai/flows/tts-flow');
-jest.mock('@/ai/flows/stt-flow');
+jest.mock('@/ai/flows/generate-chat-title', () => ({ generateChatTitle: jest.fn() }));
+jest.mock('@/ai/flows/pollinations-chat-flow', () => ({ getPollinationsChatCompletion: jest.fn() }));
+jest.mock('@/ai/flows/tts-flow', () => ({ textToSpeech: jest.fn() }));
+jest.mock('@/ai/flows/stt-flow', () => ({ speechToText: jest.fn() }));
+jest.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: jest.fn() }) }));
+
+import { useChatLogic } from '../ChatProvider';
 
 const mockGenerateChatTitle = generateChatTitle as jest.Mock;
 const mockGetPollinationsChatCompletion = getPollinationsChatCompletion as jest.Mock;
@@ -16,13 +18,8 @@ const mockTextToSpeech = textToSpeech as jest.Mock;
 
 describe('useChatLogic Hook', () => {
   beforeEach(() => {
-    // Reset mocks before each test
     jest.clearAllMocks();
     localStorage.clear();
-    // Mock the toast hook
-    jest.spyOn(require('@/hooks/use-toast'), 'useToast').mockReturnValue({
-      toast: jest.fn(),
-    });
   });
 
   it('should start a new chat', () => {

--- a/src/components/__tests__/ReplicateImageTool.test.tsx
+++ b/src/components/__tests__/ReplicateImageTool.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ReplicateImageTool from '../tools/ReplicateImageTool';
+import { modelConfigs } from '@/config/replicate-models';
+
+jest.mock('next/image', () => (props: any) => <img {...props} />);
+jest.mock('lucide-react', () => ({
+  Loader2: () => <svg />,
+  AlertCircle: () => <svg />,
+  Info: () => <svg />,
+  ImageIcon: () => <svg />,
+  X: () => <svg />,
+  MoreHorizontal: () => <svg />,
+  ChevronDown: () => <svg />,
+  FileImage: () => <svg />,
+  Plus: () => <svg />,
+}));
+
+describe('ReplicateImageTool Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('shows image preview when a file is uploaded', async () => {
+    localStorage.setItem('replicateImageToolSettings', JSON.stringify({ selectedModelKey: 'flux-kontext-pro' }));
+    const { container } = render(<ReplicateImageTool />);
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['hi'], 'pic.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(fileInput.value).toBe('');
+    await waitFor(() => expect(screen.getByAltText('Reference preview')).toBeInTheDocument());
+  });
+
+  it('submits a prompt and calls fetch', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ output: 'http://image' }) });
+    localStorage.setItem('replicateImageToolSettings', JSON.stringify({ selectedModelKey: Object.keys(modelConfigs)[0] }));
+    render(<ReplicateImageTool password="pw" />);
+    const textarea = await screen.findByLabelText('Main prompt input with dynamic height');
+    fireEvent.change(textarea, { target: { value: 'test prompt' } });
+    const executeBtn = screen.getByRole('button', { name: /Execute/i });
+    fireEvent.click(executeBtn);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- expand Jest config to transform node_modules
- mock Genkit flows earlier for proper ESM handling
- add unit tests for ChatInput and ReplicateImageTool
- add mocks in existing tests to avoid ESM modules
- include whatwg-fetch dev dependency for jest setup

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686fe08b9454832c980c49bbd4065dce